### PR TITLE
- Changing `lib_ldf_mode` from `deep+` to `deep` to fix chain-linking…

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ lib_deps =
 	contrem/arduino-timer@^2.3.1
 build_flags = 
 	-DDEBUG_ESP_PORT=Serial
-	-DBOARD_HAS_PSRAM
+	-DBOARD_HAS_PSRAM=1
 	-mfix-esp32-psram-cache-issue
 board_build.partitions = min_spiffs.csv
 release_version = 0.0.1 ; Modify with the version of the project
@@ -34,8 +34,8 @@ monitor_speed = 115200
 monitor_rts = 0
 monitor_dtr = 0
 extra_scripts = 
-	;pre:customname.py
-	;pre:inject_path.py
+	pre:customname.py
+	pre:inject_path.py
 
 [env:debug]
 platform = ${common.platform}

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,7 @@ build_flags =
 	-mfix-esp32-psram-cache-issue
 board_build.partitions = min_spiffs.csv
 release_version = 0.0.1 ; Modify with the version of the project
-lib_ldf_mode = deep+
+lib_ldf_mode = deep
 upload_speed = 921600
 monitor_speed = 115200
 monitor_rts = 0


### PR DESCRIPTION
… error in the `PageBuilder` library. `deep+` is causing `SPIFFS.h` not found during compile. `deep` fixes this issue.