### PR TITLE
Update camera.cpp - failed to build for some members of EyeTrackVR

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,7 @@ board_build.partitions = ${common.board_build.partitions}
 extra_scripts = ${common.extra_scripts}
 lib_ldf_mode = ${common.lib_ldf_mode}
 monitor_filters = 
-	colorize
+	; colorize
 	log2file
 	time
 	default

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ lib_deps =
 	contrem/arduino-timer@^2.3.1
 build_flags = 
 	-DDEBUG_ESP_PORT=Serial
-	-DBOARD_HAS_PSRAM=1
+	-DBOARD_HAS_PSRAM
 	-mfix-esp32-psram-cache-issue
 board_build.partitions = min_spiffs.csv
 release_version = 0.0.1 ; Modify with the version of the project

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -98,7 +98,7 @@ esp_err_t FuturaFaceTracker::streamHandler(httpd_req_t *req)
         fb = esp_camera_fb_get();
         if (!fb)
         {
-            ESP_LOGE(TAG, "Camera capture failed");
+            log_e("Camera capture failed");
             res = ESP_FAIL;
         }
         else

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -112,7 +112,7 @@ esp_err_t FuturaFaceTracker::streamHandler(httpd_req_t *req)
                 fb = NULL;
                 if (!jpeg_converted)
                 {
-                    ESP_LOGE(TAG, "JPEG compression failed");
+                    log_e("JPEG compression failed");
                     res = ESP_FAIL;
                 }
             }


### PR DESCRIPTION
I am creating this pull request to remove some `ESPIDF` code that somehow managed to get in. The code-base failed to compile for some friends due to this issue. I have fixed it by using the Arduino framework implementation of esp logging. 

Here is the offending line: [this line](https://github.com/Futurabeast/futura-face-cam/blob/7d53aa529c284fe1a436a961bd7b3efdfd613392/src/camera.cpp#L101)